### PR TITLE
Add SASS support for `wiredep`

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,10 @@
 {
   "name": "bootstrap-social",
-  "main": "bootstrap-social.css",
+  "main": [
+    "bootstrap-social.css",
+    "bootstrap-social.less",
+    "bootstrap-social.scss"
+  ],
   "license": "MIT",
   "ignore": [
     "assets",


### PR DESCRIPTION
The `bootstrap-social.scss` was not added to the main SASS file when using `wiredep`. This commit fixes it.
