### PR TITLE
Change Google+ logo to Google logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
             <span class="fa fa-github"></span> Sign in with GitHub
           </a>
           <a class="btn btn-block btn-social btn-google" onclick="_gaq.push(['_trackEvent', 'btn-social', 'click', 'btn-google']);">
-            <span class="fa fa-google-plus"></span> Sign in with Google
+            <span class="fa fa-google"></span> Sign in with Google
           </a>
           <a class="btn btn-block btn-social btn-instagram" onclick="_gaq.push(['_trackEvent', 'btn-social', 'click', 'btn-instagram']);">
             <span class="fa fa-instagram"></span> Sign in with Instagram


### PR DESCRIPTION
The Google+ logo doesn't work well and pushes against the edges. I'm now using the Google logo (`fa-google`) to fix that and to keep it consistent with the rest of the page.
