### PR TITLE
Stop using the reserved 'main' entry for CSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bootstrap-social",
   "version": "5.1.1",
-  "main": "bootstrap-social.css",
+  "css": "bootstrap-social.css",
   "repository": {
     "type": "git",
     "url": "https://github.com/lipis/bootstrap-social.git"


### PR DESCRIPTION
Uses 'css' field instead.

Fix for #122.