### PR TITLE
Fixed issue in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,12 @@ Examples
 
 ```html
 <a class="btn btn-block btn-social btn-twitter">
-  <span class="fa fa-twitter"></span>
+  <span class="fab fa-twitter"></span>
   Sign in with Twitter
 </a>
 
 <a class="btn btn-social-icon btn-twitter">
-  <span class="fa fa-twitter"></span>
+  <span class="fab fa-twitter"></span>
 </a>
 ```
 


### PR DESCRIPTION
Using your example only showed a dashed circle with a flashing questionmark and exclamationmark instead of the icon. [Turns out the class is `fab`](https://stackoverflow.com/a/49322196/2550406), and not `fa`, for brands.